### PR TITLE
Pamf 678/edit trip info

### DIFF
--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -208,6 +208,10 @@ $kioskfonts: "Avenir Next", "Helvetica Neue", Helvetica, sans-serif;
   box-shadow: 0px 2px 8px rgba(0,0,0,0.4);
 }
 
+.no-shadow {
+  box-shadow: none;
+}
+
 .debug {
   visibility: hidden;
 }

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -208,10 +208,6 @@ $kioskfonts: "Avenir Next", "Helvetica Neue", Helvetica, sans-serif;
   box-shadow: 0px 2px 8px rgba(0,0,0,0.4);
 }
 
-.no-shadow {
-  box-shadow: none;
-}
-
 .debug {
   visibility: hidden;
 }
@@ -699,4 +695,22 @@ ul.bus-nav-tabs.nav-tabs {
 
 #itinerary .row.live-trip {
   background-color: $live-yellow;
+}
+
+.btn-no-bg {
+  background-color: transparent;
+  box-shadow: none;
+  color: black;
+  text-decoration: none;
+  &:hover, &:focus {
+    color:#00884B;
+    outline: #00884b solid 2px;
+    ;
+  }
+}
+
+.container--center-single-item {
+  display: flex;
+  justify-content: center;
+  align-items: baseline;
 }

--- a/app/views/plan-confirm.html.haml
+++ b/app/views/plan-confirm.html.haml
@@ -15,8 +15,8 @@
             {{request.fromLine1}}
           %h5.text-muted.text-left
             {{request.fromLine2 | noCountry}}
-        .col-xs-3.col-md-2
-          %button.btn.btn-link.no-shadow{title:'Edit Trip Origin',ng:{click: 'goPlanWhere()'}, type: 'button'}
+        .col-xs-3.col-md-2.container--center-single-item
+          %button.btn.btn-no-bg{title:'Edit Trip Origin',ng:{click: 'goPlanWhere()'}, type: 'button'}
             %i.glyphicon.glyphicon-pencil
       .no_underline.row.rounded-border{ng:{click:'goPlanWhere()'}}
         .col-xs-3.col-md-2
@@ -27,8 +27,8 @@
             {{request.toLine1}}
           %h5.text-muted.text-left
             {{request.toLine2 | noCountry}}
-        .col-xs-3.col-md-2
-          %button.btn.btn-link.no-shadow{title:'Edit Trip Destination',ng:{click: 'goPlanWhere()'}, type: 'button'}
+        .col-xs-3.col-md-2.container--center-single-item
+          %button.btn.btn-no-bg{title:'Edit Trip Destination',ng:{click: 'goPlanWhere()'}, type: 'button'}
             %i.glyphicon.glyphicon-pencil
       .no_underline.row.rounded-border{ng: {show: '!request.roundtrip || request.sameday', click:'goPlanWhen()' } }
         .col-xs-3.col-md-2
@@ -41,8 +41,8 @@
               {{request.when2}}
             %h5.text-muted.text-left{ng: {show: 'request.when4'}}
               {{request.when4}}
-        .col-xs-3.col-md-2
-          %button.btn.btn-link.no-shadow{title:'Edit Trip Time',ng:{click: 'goPlanWhen()'}, type: 'button'}
+        .col-xs-3.col-md-2.container--center-single-item
+          %button.btn.btn-no-bg{title:'Edit Trip Time',ng:{click: 'goPlanWhen()'}, type: 'button'}
             %i.glyphicon.glyphicon-pencil
       .no_underline.rounded-border{style: "margin-left: -15px; margin-right: -15px;", ng: {show: 'request.roundtrip && !request.sameday', click:'goPlanWhen()'}}
         .row{style: "margin-left: 0px; margin-right: 0px;"}
@@ -70,8 +70,8 @@
         .col-xs-6.col-md-8
           %h4.text-left
             {{request.purpose}}
-        .col-xs-3.col-md-2
-          %button.btn.btn-link.no-shadow{title:'Edit Trip Purpose',ng:{click: 'goPlanPurpose()'}, type: 'button'}
+        .col-xs-3.col-md-2.container--center-single-item
+          %button.btn.btn-no-bg{title:'Edit Trip Purpose',ng:{click: 'goPlanPurpose()'}, type: 'button'}
             %i.glyphicon.glyphicon-pencil
       .row.rounded-border{'ng-hide'=>'showBusRides || paratransitItineraries.length == 0'}
         .col-xs-3.col-md-2

--- a/app/views/plan-confirm.html.haml
+++ b/app/views/plan-confirm.html.haml
@@ -10,34 +10,40 @@
         .col-xs-3.col-md-2
           %p.text-left.text-muted
             From
-        .col-xs-9.col-md-10
+        .col-xs-6.col-md-8
           %h4.text-left
             {{request.fromLine1}}
           %h5.text-muted.text-left
             {{request.fromLine2 | noCountry}}
-
+        .col-xs-3.col-md-2
+          %button{ng:{click: 'goPlanWhere()'}, type: 'button'}
+            %i.glyphicon.glyphicon-pencil
       .no_underline.row.rounded-border{ng:{click:'goPlanWhere()'}}
         .col-xs-3.col-md-2
           %p.text-left.text-muted
             To
-        .col-xs-9.col-md-10
+        .col-xs-6.col-md-8
           %h4.text-left
             {{request.toLine1}}
           %h5.text-muted.text-left
             {{request.toLine2 | noCountry}}
-
+        .col-xs-3.col-md-2
+          %button{ng:{click: 'goPlanWhere()'}, type: 'button'}
+            %i.glyphicon.glyphicon-pencil
       .no_underline.row.rounded-border{ng: {show: '!request.roundtrip || request.sameday', click:'goPlanWhen()' } }
         .col-xs-3.col-md-2
           %p.text-left.text-muted
             When
-        .col-xs-9.col-md-10
+        .col-xs-6.col-md-8
           %h4.text-left
             {{request.when1}}
             %h5.text-muted.text-left
               {{request.when2}}
             %h5.text-muted.text-left{ng: {show: 'request.when4'}}
               {{request.when4}}
-
+        .col-xs-3.col-md-2
+          %button{ng:{click: 'goPlanWhen()'}, type: 'button'}
+            %i.glyphicon.glyphicon-pencil
       .no_underline.rounded-border{style: "margin-left: -15px; margin-right: -15px;", ng: {show: 'request.roundtrip && !request.sameday', click:'goPlanWhen()'}}
         .row{style: "margin-left: 0px; margin-right: 0px;"}
           .col-xs-3.col-md-2
@@ -57,19 +63,21 @@
               {{request.when3}}
             %h5.text-muted.text-left
               {{request.when4}}
-
       .no_underline.row.rounded-border{ng:{show:'request.purpose', click:'goPlanPurpose()'}}
         .col-xs-3.col-md-2
           %p.text-left.text-muted
             Purpose
-        .col-xs-9.col-md-10
+        .col-xs-6.col-md-8
           %h4.text-left
             {{request.purpose}}
+        .col-xs-3.col-md-2
+          %button{ng:{click: 'goPlanPurpose()'}, type: 'button'}
+            %i.glyphicon.glyphicon-pencil
       .row.rounded-border{'ng-hide'=>'showBusRides || paratransitItineraries.length == 0'}
         .col-xs-3.col-md-2
           %p.text-left.text-muted
             Cost
-        .col-xs-9.col-md-10
+        .col-xs-6.col-md-8
           %h4.text-left
             {{fare_info["mode_paratransit"]}}
 

--- a/app/views/plan-confirm.html.haml
+++ b/app/views/plan-confirm.html.haml
@@ -16,7 +16,7 @@
           %h5.text-muted.text-left
             {{request.fromLine2 | noCountry}}
         .col-xs-3.col-md-2
-          %button{ng:{click: 'goPlanWhere()'}, type: 'button'}
+          %button.btn.btn-link.no-shadow{title:'Edit Trip Origin',ng:{click: 'goPlanWhere()'}, type: 'button'}
             %i.glyphicon.glyphicon-pencil
       .no_underline.row.rounded-border{ng:{click:'goPlanWhere()'}}
         .col-xs-3.col-md-2
@@ -28,7 +28,7 @@
           %h5.text-muted.text-left
             {{request.toLine2 | noCountry}}
         .col-xs-3.col-md-2
-          %button{ng:{click: 'goPlanWhere()'}, type: 'button'}
+          %button.btn.btn-link.no-shadow{title:'Edit Trip Destination',ng:{click: 'goPlanWhere()'}, type: 'button'}
             %i.glyphicon.glyphicon-pencil
       .no_underline.row.rounded-border{ng: {show: '!request.roundtrip || request.sameday', click:'goPlanWhen()' } }
         .col-xs-3.col-md-2
@@ -42,7 +42,7 @@
             %h5.text-muted.text-left{ng: {show: 'request.when4'}}
               {{request.when4}}
         .col-xs-3.col-md-2
-          %button{ng:{click: 'goPlanWhen()'}, type: 'button'}
+          %button.btn.btn-link.no-shadow{title:'Edit Trip Time',ng:{click: 'goPlanWhen()'}, type: 'button'}
             %i.glyphicon.glyphicon-pencil
       .no_underline.rounded-border{style: "margin-left: -15px; margin-right: -15px;", ng: {show: 'request.roundtrip && !request.sameday', click:'goPlanWhen()'}}
         .row{style: "margin-left: 0px; margin-right: 0px;"}
@@ -71,7 +71,7 @@
           %h4.text-left
             {{request.purpose}}
         .col-xs-3.col-md-2
-          %button{ng:{click: 'goPlanPurpose()'}, type: 'button'}
+          %button.btn.btn-link.no-shadow{title:'Edit Trip Purpose',ng:{click: 'goPlanPurpose()'}, type: 'button'}
             %i.glyphicon.glyphicon-pencil
       .row.rounded-border{'ng-hide'=>'showBusRides || paratransitItineraries.length == 0'}
         .col-xs-3.col-md-2


### PR DESCRIPTION
# [Ticket](https://issuetracker.camsys.com/browse/PAMF-678) and Ticket Overview
A trivial enhancement was proposed that would update the Trip Confirmation page to show a visual indicator of some sort that would indicate that a user could edit any of the fields on the confirmation page. This PR does that and adds a pencil icon to each field. It links to the corresponding Trip Planning page and has focus/ hover states.

# Visual Demo of Changes
![pamf-678-edit-buttons](https://user-images.githubusercontent.com/12119553/118993373-761d7c00-b953-11eb-87eb-1aac2fac6088.png)
- Edit button default state
- 
![pamf-678-edit-button-focus](https://user-images.githubusercontent.com/12119553/118993371-761d7c00-b953-11eb-8821-448ca04f57f5.png)
- Edit button focus state

![pamf-678-edit-purpose](https://user-images.githubusercontent.com/12119553/118993399-7cabf380-b953-11eb-8c55-177f1a39a8af.gif)
