### PR TITLE
Pamf 679/swap address btn

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -153,6 +153,7 @@
         <script src="scripts/services/filters.js"></script>
         <script src="scripts/services/plan.js"></script>
         <script src="scripts/services/util.js"></script>
+        <script src="scripts/factories/debounce.js"></script>
         <script src="scripts/directives/calendar.js"></script>
         <script src="scripts/directives/time.js"></script>
         <script src="scripts/directives/clickFocus.js"></script>

--- a/app/scripts/controllers/plan.js
+++ b/app/scripts/controllers/plan.js
@@ -806,13 +806,34 @@ function($scope, $http, $routeParams, $location, planService, util, flash, usSpi
     $scope.selectPlace(place, 'to');
   }
 
-  
-  // This is run when you click a place in the list, 
-  // when you tap out of the to/from field, 
-  // and when the to/from page is loaded
-  $scope.selectPlace = function(place, toFrom, loadLocationsIfNeeded){
+  /**
+   * Swap to/from click handler
+   * @returns {void}
+   */
+  $scope.swapToFromInputs = function() {
+    const to = $scope.to !== '' ? $scope.to : $scope.toDefault
+    const from = $scope.from !== '' ? $scope.from : $scope.fromDefault
 
-    // Check to see if we have reset to the original place. If so, we can turn the button back on.     
+    $scope.selectPlace(from , 'to', true)
+    $scope.selectPlace(to , 'from', true)
+    $scope.to = from
+
+    $scope.from = to
+  }
+
+  /**
+   * Select Place
+   * - This is run when you click a place in the list,
+   * ...when you tap out of the to/from field,
+   * ...and when the to/from page is loaded
+   * - if the place is selected successfully
+   * ...$scope.checkServiceArea is called
+   * @param {string} place - an address
+   * @param {string} toFrom - limited to a value of 'to' or 'from
+   * @param {unknown} loadLocationsIfneeded - unsure
+   */
+  $scope.selectPlace = function(place, toFrom, loadLocationsIfNeeded){
+    // Check to see if we have reset to the original place. If so, we can turn the button back on.
     if(toFrom == 'from'){
       if(place === $scope.fromDefault && place.length > 0){
         $scope.locationClicked = true

--- a/app/scripts/directives/autocomplete.js
+++ b/app/scripts/directives/autocomplete.js
@@ -273,6 +273,7 @@ app.directive('autocomplete', function() {
             class="clearable {{ attrs.inputclass }}"\
             id="{{ attrs.inputid }}"\
             autocomplete="off"\
+            ng-model-options="{ debounce: 100 }"\
             ng-required="{{ autocompleteRequired }}" />\
           <ul ng-show="completing && (suggestions | filter:searchFilter).length > 0">\
             <li\

--- a/app/scripts/factories/debounce.js
+++ b/app/scripts/factories/debounce.js
@@ -1,0 +1,41 @@
+var app = angular.module('applyMyRideApp');
+
+app.factory('debounce', ['$timeout', '$q', function($timeout, $q) {
+  /**
+   * Angular JS Debounce factory
+   * - only exists to debounce function calls so we can't spam a button over and over
+   * - taken from this StackOverflow post: https://stackoverflow.com/questions/13320015/how-to-write-a-debounce-service-in-angularjs
+   *
+   * @param {Function} func - the input function to be debounced
+   * @param {number} wait - wait time before executing the function in milliseconds
+   * @param {Boolean} immediate - run the input function immediately?
+   */
+  return function debounce(func, wait, immediate) {
+    let timeout
+    // Create a deferred object that will be resolved when we need to
+    // ... actually call the function
+    // The Deferred object represents a task to be finished in the future
+    let deferred = $q.defer() // $q is a service that lets your run functions asynchronously
+    return function() {
+      let context = this
+      let args = arguments;
+      const later = function() {
+        timeout = null;
+        if(!immediate) {
+          deferred.resolve(func.apply(context, args));
+          deferred = $q.defer();
+        }
+      };
+      const callNow = immediate && !timeout;
+      if ( timeout ) {
+        $timeout.cancel(timeout);
+      }
+      timeout = $timeout(later, wait);
+      if (callNow) {
+        deferred.resolve(func.apply(context,args));
+        deferred = $q.defer();
+      }
+      return deferred.promise;
+    };
+  }
+}])

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -696,3 +696,34 @@ ul.bus-nav-tabs.nav-tabs {
 #itinerary .row.live-trip {
   background-color: $live-yellow;
 }
+button.btn--no-outline {
+  border: none;
+  box-shadow: none;
+  background: transparent;
+  font-size: 24px;
+  &:hover {
+    // FIXME REPLACE THIS WITH SOMETHING PROPER
+    color: $green;
+  }
+}
+
+.input-row--address{
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0 -15px;
+}
+
+.h3--address-label {
+  display: flex;
+  align-items: center;
+  font-weight: bold;
+  margin: 10px 0;
+}
+
+.container__swap-btn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 50px;
+}

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -701,9 +701,8 @@ button.btn--no-outline {
   box-shadow: none;
   background: transparent;
   font-size: 24px;
-  &:hover {
-    // FIXME REPLACE THIS WITH SOMETHING PROPER
-    color: $green;
+  &:hover:not(:disabled) {
+    color: #00884b;
   }
 }
 

--- a/app/views/plan.html.haml
+++ b/app/views/plan.html.haml
@@ -9,61 +9,64 @@
         .form-group
           .row
             .col-lg-6.col-lg-offset-3.col-md-8.col-md-offset-2.col-sm-10.col-sm-offset-1.col-xs-12
-              %h3
-                %strong
-                  %i{class:'cs-map-marker A'}
-                  Where are you starting?
+              .input-row--address
+                .col-lg-10.col-md-10.col-sm-10
+                  %label.h3.h3--address-label{for: 'fromInput'}
+                    %i{class:'cs-map-marker A'}
+                    Where are you starting?
 
-              %autocomplete{ 'attr-placeholder'=> '{{fromDefault}}',
-                                          'attr-input-id' => 'whereFromInput',
-                                          'attr-autofocus' => 'true',
-                                          'attr-clicktofocus' => 'true',
-                                          class: 'autocompleteWrapper',
-                                          id: 'fromInput',
-                                          tabindex: 'null',
-                                          required: 'true',
-                                          'inputclass' => 'clearable tripplanner__location form__input',
-                                          'disable-filter' => 'true',
-                                          'data' => 'locations',
-                                          'attr-input-class' => 'whereToFrom',
-                                          'on-type'=> 'getFromLocations',
-                                          'on-focus'=> 'focusFrom',
-                                          'on-blur'=> 'mapFrom',
-                                          'on-select' => 'selectFrom',
-                                          'autocomplete-required' => 'true',
-                                          ng: { model: 'from'} }
-              .alert.alert-danger{role:'alert', ng:{show:'errors.noResultsfrom'}}
-                Address is not recognized.  Try entering it another way.
-              .alert.alert-danger{role:'alert', ng:{show:'errors.rangeErrorfrom'}}
-                The location you selected is outside the service area.
+                  %autocomplete{ 'attr-placeholder'=> '{{fromDefault}}',
+                                              'attr-input-id' => 'whereFromInput',
+                                              'attr-autofocus' => 'true',
+                                              'attr-clicktofocus' => 'true',
+                                              class: 'autocompleteWrapper',
+                                              id: 'fromInput',
+                                              tabindex: 'null',
+                                              required: 'true',
+                                              'inputclass' => 'clearable tripplanner__location form__input',
+                                              'disable-filter' => 'true',
+                                              'data' => 'locations',
+                                              'attr-input-class' => 'whereToFrom',
+                                              'on-type'=> 'getFromLocations',
+                                              'on-focus'=> 'focusFrom',
+                                              'on-blur'=> 'mapFrom',
+                                              'on-select' => 'selectFrom',
+                                              'autocomplete-required' => 'true',
+                                              ng: { model: 'from'} }
+                  .alert.alert-danger{role:'alert', ng:{show:'errors.noResultsfrom'}}
+                    Address is not recognized.  Try entering it another way.
+                  .alert.alert-danger{role:'alert', ng:{show:'errors.rangeErrorfrom'}}
+                    The location you selected is outside the service area.
 
-              %h3
-                %strong
-                  %i{class:'cs-map-marker B'}
-                  Where are you going?
+                  %label.h3.h3--address-label{for: 'toInput'}
+                    %i{class:'cs-map-marker B'}
+                    Where are you going?
 
-              %autocomplete{ 'attr-placeholder'=> '{{toDefault}}',
-                                          'attr-input-id' => 'whereToInput',
-                                          'attr-clicktofocus' => 'true',
-                                          class: 'autocompleteWrapper',
-                                          id: 'toInput',
-                                          tabindex: 'null',
-                                          required: 'true',
-                                          'inputclass' => 'clearable tripplanner__location form__input',
-                                          'disable-filter' => 'true',
-                                          'data' => 'locations',
-                                          'on-type'=> 'getToLocations',
-                                          'on-focus'=> 'focusTo',
-                                          'on-blur'=> 'mapTo',
-                                          'on-select' => 'selectTo',
-                                          'autocomplete-required' => 'true',
-                                          ng: { model: 'to'} }
+                  %autocomplete{ 'attr-placeholder'=> '{{toDefault}}',
+                                              'attr-input-id' => 'whereToInput',
+                                              'attr-clicktofocus' => 'true',
+                                              class: 'autocompleteWrapper',
+                                              id: 'toInput',
+                                              tabindex: 'null',
+                                              required: 'true',
+                                              'inputclass' => 'clearable tripplanner__location form__input',
+                                              'disable-filter' => 'true',
+                                              'data' => 'locations',
+                                              'on-type'=> 'getToLocations',
+                                              'on-focus'=> 'focusTo',
+                                              'on-blur'=> 'mapTo',
+                                              'on-select' => 'selectTo',
+                                              'autocomplete-required' => 'true',
+                                              ng: { model: 'to'} }
 
-              .alert.alert-danger{role:'alert', ng:{show:'errors.noResultsto'}}
-                Address is not recognized.  Try entering it another way.
+                  .alert.alert-danger{role:'alert', ng:{show:'errors.noResultsto'}}
+                    Address is not recognized.  Try entering it another way.
 
-              .alert.alert-danger{role:'alert', ng:{show:'errors.rangeErrorto'}}
-                The location you selected is outside the service area.
+                  .alert.alert-danger{role:'alert', ng:{show:'errors.rangeErrorto'}}
+                    The location you selected is outside the service area.
+                .col-lg-2.col-md-2.col-sm-2.container__swap-btn
+                  %button.btn.btn--no-outline{type:'button'}
+                    %i.glyphicon.glyphicon-sort
 
               %div.map-canvas{'ui-map' => 'whereToMap', 'ui-options' => 'mapOptions', ng: {show: 'showMap'}}
 

--- a/app/views/plan.html.haml
+++ b/app/views/plan.html.haml
@@ -41,7 +41,6 @@
                   %label.h3.h3--address-label{for: 'toInput'}
                     %i{class:'cs-map-marker B'}
                     Where are you going?
-
                   %autocomplete{ 'attr-placeholder'=> '{{toDefault}}',
                                               'attr-input-id' => 'whereToInput',
                                               'attr-clicktofocus' => 'true',
@@ -65,7 +64,7 @@
                   .alert.alert-danger{role:'alert', ng:{show:'errors.rangeErrorto'}}
                     The location you selected is outside the service area.
                 .col-lg-2.col-md-2.col-sm-2.container__swap-btn
-                  %button.btn.btn--no-outline{type:'button', ng: {click: 'swapToFromInputs()'}}
+                  %button.btn.btn--no-outline{type:'button', aria: {label: 'Swap Address Inputs'},ng: {click: 'debouncedSwapAddressInputs()', disabled: 'disableSwapAddressButton == true'}}
                     %i.glyphicon.glyphicon-sort
 
               %div.map-canvas{'ui-map' => 'whereToMap', 'ui-options' => 'mapOptions', ng: {show: 'showMap'}}

--- a/app/views/plan.html.haml
+++ b/app/views/plan.html.haml
@@ -65,7 +65,7 @@
                   .alert.alert-danger{role:'alert', ng:{show:'errors.rangeErrorto'}}
                     The location you selected is outside the service area.
                 .col-lg-2.col-md-2.col-sm-2.container__swap-btn
-                  %button.btn.btn--no-outline{type:'button'}
+                  %button.btn.btn--no-outline{type:'button', ng: {click: 'swapToFromInputs()'}}
                     %i.glyphicon.glyphicon-sort
 
               %div.map-canvas{'ui-map' => 'whereToMap', 'ui-options' => 'mapOptions', ng: {show: 'showMap'}}


### PR DESCRIPTION
# Ticket and Ticket Overview
An optional enhancement that adds a Swap Address Fields button to the Plan Trip Origin/ Destination page.  This PR does that and the general user flow for interacting with it is:
1. User inputs an origin and destination
2. User clicks the swap address fields button
3. User waits for the swap operation to happen
  - swap button and the Yes Looks Good button is disabled for the duration of the swap
4. Origin and destination fields finish swapping and the Yes Looks Good button is re-enabled
5. User proceeds through the rest of the trip booking flow and can book/ select a trip like normal

# Visual Demo of Changes

https://user-images.githubusercontent.com/12119553/119527333-3937f780-bd4e-11eb-8196-5a16afed21e2.mov

