### PR TITLE
PAMF-696 ecolane missing city

### DIFF
--- a/app/scripts/controllers/plan.js
+++ b/app/scripts/controllers/plan.js
@@ -841,6 +841,23 @@ function($scope, $http, $routeParams, $location, planService, util, flash, usSpi
     await debounce($scope.swapAddressInputs, 450)()
     $scope.disableSwapAddressButton = false
   }
+
+  const validateCityPresence = function(place) {
+    const addressComponents = place.address_components
+    const ADMIN_AREA_3 = 'administrative_area_level_3'
+    const PENN = 'Pennsylvania'
+    const locality = addressComponents.find(function(component) {
+      const includesLocality = component.types.includes('locality') && component.long_name != null
+      const includesAdminArea = component.types.includes(ADMIN_AREA_3) && component.long_name !== PENN && component.long_name !== 'US'  && component.long_name != null
+      if (includesLocality || includesAdminArea) {
+        return true
+      } else {
+        return false
+      }
+    });
+    console.log(locality)
+   return locality != null
+  }
   /**
    * Select Place
    * - This is run when you click a place in the list,
@@ -894,9 +911,15 @@ function($scope, $http, $routeParams, $location, planService, util, flash, usSpi
     }
     // The person selected a POI
     else if(-1 < selectedIndex && selectedIndex < $scope.poiData.length){
-      $scope.locationClicked = true;
-      $scope.poi = $scope.poiData[selectedIndex];
-      $scope.checkServiceArea($scope.poi, $scope.poi.formatted_address, toFrom);
+      const hasCity = validateCityPresence($scope.poiData[selectedIndex])
+      if (hasCity) {
+        $scope.locationClicked = true;
+        $scope.poi = $scope.poiData[selectedIndex];
+        $scope.checkServiceArea($scope.poi, $scope.poi.formatted_address, toFrom);
+      } else {
+        bootbox.alert("Selected Point of Interest has no city, please search for another address.")
+        return
+      }
     }
     // The person selected either a recent place or a Google Place.
     else{
@@ -953,7 +976,6 @@ function($scope, $http, $routeParams, $location, planService, util, flash, usSpi
           });
       }
 
-      
       // After a location has been picked or entered into the to/from field, we then Geocode that location
       // TODO: Why are we re-geocoding? If the autocomplete/Poi already has a lat/lng, this isn't necessary
       // This is only necessary for manual entry, which we no longer do.
@@ -965,14 +987,17 @@ function($scope, $http, $routeParams, $location, planService, util, flash, usSpi
           }, function (result, status) {
             if (status == google.maps.GeocoderStatus.OK) {
 
-            //verify the location has a street address
-            var datatypes = [];
-            var route;
+            /* Verify that a street number and a locality/ city exists in the returned place */
+            const datatypes = [];
+            let route;
             angular.forEach(result.address_components, function(component, index) {
               angular.forEach(component.types, function(type, index) {
-                datatypes.push(type);
-                if(type == 'route'){
-                  route = component.long_name;
+                // if the component isn't empty, then push it into datatypes and parse the route
+                if (component.long_name != null) {
+                  datatypes.push(type);
+                  if(type == 'route'){
+                    route = component.long_name;
+                  }
                 }
               });
             });
@@ -1003,6 +1028,10 @@ function($scope, $http, $routeParams, $location, planService, util, flash, usSpi
                   return;
                 }
               }
+            } else if (datatypes.indexOf('locality') < 0 && datatypes.indexOf('administrative_area_level_3') < 0) {
+              checkShowMap();
+              bootbox.alert("The location you selected does not have a city associated to it, please select another location.");
+              return;
             }
 
             // When we start typing we hide the Yes, looks good! button. 

--- a/app/scripts/controllers/plan.js
+++ b/app/scripts/controllers/plan.js
@@ -579,7 +579,13 @@ function($scope, $http, $routeParams, $location, planService, util, flash, usSpi
   }
 
   function _bookTrip(){
-    planService.prepareConfirmationPage($scope);
+    try {
+      planService.prepareConfirmationPage($scope);
+    } catch (e) {
+      console.log(e.message)
+      bootbox.alert('The origin/ destination address does not have a city included. Please go back and use a different address with a city included.')
+      return
+    }
     planService.transitResult = [];
     planService.paratransitResult = null;
     usSpinnerService.spin('spinner-1');

--- a/app/scripts/controllers/plan.js
+++ b/app/scripts/controllers/plan.js
@@ -1125,10 +1125,13 @@ function($scope, $http, $routeParams, $location, planService, util, flash, usSpi
       return name + ', ' + vicinity;
     }
 
-    // Find the City name from the address_components. In the Google framework, the city name is 'locality'
+    // Find the City name from the address_components.
+    // In the Google framework, the city name can be 'locality' or 'administrative_area_level_3' if 'locality' isn't present
     angular.forEach(gPlace['address_components'], function(value, key) {
       var types = value['types'];
       if($.inArray('locality',types) >= 0){
+        city = value['long_name']
+      } else if($.inArray('administrative_area_level_3',types) >= 0){
         city = value['long_name']
       }
     })

--- a/app/scripts/controllers/plan.js
+++ b/app/scripts/controllers/plan.js
@@ -582,7 +582,6 @@ function($scope, $http, $routeParams, $location, planService, util, flash, usSpi
     try {
       planService.prepareConfirmationPage($scope);
     } catch (e) {
-      console.log(e.message)
       bootbox.alert('The origin/ destination address does not have a city included. Please go back and use a different address with a city included.')
       return
     }
@@ -861,7 +860,6 @@ function($scope, $http, $routeParams, $location, planService, util, flash, usSpi
         return false
       }
     });
-    console.log(locality)
    return locality != null
   }
   /**

--- a/app/scripts/services/plan.js
+++ b/app/scripts/services/plan.js
@@ -811,17 +811,17 @@ angular.module('applyMyRideApp')
        * @param {*} location : A location returned by the Google Place API
        */
       this.addCityToLocation = function(location) {
-        const ADMIN_AREA = 'administrative_area_level_3'
+        const ADMIN_AREA_3 = 'administrative_area_level_3'
         let street_address;
         const localityAvailable = location.address_components.find(function(component) {
           return component.types.includes('locality')
         })
 
         if (!localityAvailable) {
-          // pull administrative locality level 3 instead
+          // pull administrative locality level 3 instead if locality isn't present
           street_address = location.address_components.find(function(component) {
-            const includesAdmin = component.types.includes(ADMIN_AREA)
-            return includesAdmin
+            const includesAdmin3 = component.types.includes(ADMIN_AREA_3)
+            return includesAdmin3 && component.long_name !== 'Pennsylvania'
           }).long_name
 
           location.address_components.push(

--- a/app/scripts/services/plan.js
+++ b/app/scripts/services/plan.js
@@ -814,15 +814,19 @@ angular.module('applyMyRideApp')
         const ADMIN_AREA_3 = 'administrative_area_level_3'
         let street_address;
         const localityAvailable = location.address_components.find(function(component) {
-          return component.types.includes('locality')
+          return component.types.includes('locality') && component.long_name !== null
         })
 
         if (!localityAvailable) {
           // pull administrative locality level 3 instead if locality isn't present
           street_address = location.address_components.find(function(component) {
             const includesAdmin3 = component.types.includes(ADMIN_AREA_3)
-            return includesAdmin3 && component.long_name !== 'Pennsylvania'
-          }).long_name
+            return includesAdmin3 && component.long_name !== 'Pennsylvania' && component.long_name !== null
+          })
+
+          if (!street_address || street_address.long_name === null) {
+            throw new Error(`The "${location.name}" address does not have a city. Please search again for an address with the city included.`)
+          }
 
           location.address_components.push(
             {


### PR DESCRIPTION
# [Ticket](https://issuetracker.camsys.com/browse/PAMF-696)
Add code to either return an error alert if the location has no city, or silently resolve it if a Township is included.

Also adds a fix for [PAMF-628](https://issuetracker.camsys.com/browse/PAMF-628)

See related [OCC Pull Request](https://github.com/camsys/oneclick-core/pull/219)