### PR TITLE
PAMF-848

### DIFF
--- a/app/views/login.html.haml
+++ b/app/views/login.html.haml
@@ -74,7 +74,7 @@
             .pull-right{ng:{hide: 'isTransitionCounty(county)'}}
               %a.btn.btn-primary{href: "", ng: {disabled: 'disableNext', click: 'next()'}, role: 'button'}
                 Next
-        .row.text-center{style:'margin: 30px -50px 10px -50px;'}
+        .row.text-center{style:'margin: 30px 0px 10px 0px;'}
           Need Help? Please contact your Local Transit Agency 
           %a{href: "https://www.findmyride.penndot.pa.gov/fmr-edu/home/contact", target: "_blank", rel: "noopener noreferrer"} 
             %span.glyphicon.glyphicon-new-window


### PR DESCRIPTION
Preventing 'need help?' prompt from running off page on mobile. The line now automatically doubles over on desktop, as opposed to being all in one line, but it no longer overlaps on any screen.
![Screenshot 2023-04-24 at 4 29 56 PM](https://user-images.githubusercontent.com/97370779/234121125-bc3fdeda-3ca0-4346-8cea-52d5e18d1750.png)
